### PR TITLE
Add beacon backend connector

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -151,3 +151,21 @@ export const scan = async (
     }),
   })
 }
+
+export const getBeacon = async (uuid: string, major: number, minor: number) => {
+  return fetch(
+    API_URL +
+      '/beacon?' +
+      new URLSearchParams({
+        uuid,
+        major: major.toString(),
+        minor: minor.toString(),
+      }),
+    {
+      method: 'GET',
+      sslPinning: {
+        certs: [SSL_PINNING_CERT_NAME],
+      },
+    },
+  )
+}

--- a/src/services/beacon-lookup.ts
+++ b/src/services/beacon-lookup.ts
@@ -1,0 +1,63 @@
+import { getBeacon } from '../api'
+
+interface BeaconDetail {
+  uuid: string
+  major: number
+  minor: number
+}
+
+interface CacheDetail {
+  anonymousId: string
+  lastUpdate: number
+}
+
+interface BeaconCache {
+  [detail: string]: CacheDetail
+}
+
+class BeaconLookup {
+  cache: BeaconCache
+
+  constructor() {
+    this.cache = {} as BeaconCache
+  }
+
+  private beaconToString({ uuid, major, minor }: BeaconDetail): string {
+    return `${uuid}-${major}-${minor}`
+  }
+
+  public async findBeaconAnonymousId(
+    uuid: string,
+    major: number,
+    minor: number,
+  ): Promise<string | null> {
+    const beacon = { uuid, major, minor } as BeaconDetail
+    const beaconStr = this.beaconToString(beacon)
+    const now = Date.now()
+
+    if (beaconStr in this.cache) {
+      // data exists in cache
+      const { anonymousId, lastUpdate } = this.cache[beaconStr]
+      if (now - lastUpdate < 24 * 60 * 1000) {
+        // just only one query per day
+        return anonymousId
+      }
+    }
+
+    try {
+      const response = await getBeacon(uuid, major, minor)
+      const { anonymousId } = await response.json()
+      // save data in the cache
+      this.cache[beaconStr] = {
+        anonymousId,
+        lastUpdate: now,
+      }
+      return anonymousId
+    } catch (e) {
+      // cannot find the data
+      return null
+    }
+  }
+}
+
+export const beaconLookup = new BeaconLookup()

--- a/src/services/contact-tracing-provider.tsx
+++ b/src/services/contact-tracing-provider.tsx
@@ -294,7 +294,7 @@ export class ContactTracerProvider extends React.Component<
     }
   }
 
-  onNearbyBeaconFoundReceived = (e) => {
+  onNearbyBeaconFoundReceived = async (e) => {
     this.appendStatusText('')
     this.appendStatusText('***** Found Beacon: ' + e.uuid)
     this.appendStatusText('***** major: ' + e.major)

--- a/src/services/contact-tracing-provider.tsx
+++ b/src/services/contact-tracing-provider.tsx
@@ -4,9 +4,11 @@ import {
   DeviceEventEmitter,
   NativeModules,
   Platform,
+  EventSubscription,
 } from 'react-native'
 import { requestLocationPermission } from '../utils/Permission'
 import { bluetoothScanner } from './contact-scanner'
+import { beaconLookup } from './beacon-lookup'
 
 const eventEmitter = new NativeEventEmitter(NativeModules.ContactTracerModule)
 
@@ -304,6 +306,16 @@ export class ContactTracerProvider extends React.Component<
     /* broadcast */
     console.log('broadcast:' + name)
     bluetoothScanner.add(name)
+
+    // fetch anonymousId from beaconLookup service
+    const anonymousId = await beaconLookup.findBeaconAnonymousId(
+      e.uuid,
+      e.major,
+      e.minor,
+    )
+    if (!anonymousId) return
+    bluetoothScanner.add(anonymousId)
+
     if (Date.now() - bluetoothScanner.oldestItemTS > 30 * 60 * 1000) {
       bluetoothScanner.upload()
     }


### PR DESCRIPTION
Add get beacon details API calling service.
- This also includes a simple cache that only fetch the detail only once per day per beacon device uuid.